### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.hxc linguist-language=Haxe


### PR DESCRIPTION
Allows .hxc files to be identified as Haxe on GitHub